### PR TITLE
feat: add task context and pause flag

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "semi": true,
   "trailingComma": "es5",
   "singleQuote": false,

--- a/src/db/schema.sql
+++ b/src/db/schema.sql
@@ -24,6 +24,8 @@ CREATE TABLE IF NOT EXISTS tasks (
     description TEXT NOT NULL,
     status TEXT NOT NULL CHECK(status IN ('todo', 'in-progress', 'review', 'done')),
     priority TEXT NOT NULL CHECK(priority IN ('high', 'medium', 'low')),
+    context TEXT,
+    paused INTEGER NOT NULL DEFAULT 0,
     created_at TEXT NOT NULL, -- ISO8601 format
     updated_at TEXT NOT NULL, -- ISO8601 format
     FOREIGN KEY (project_id) REFERENCES projects(project_id) ON DELETE CASCADE,

--- a/src/repositories/TaskRepository.ts
+++ b/src/repositories/TaskRepository.ts
@@ -10,6 +10,8 @@ export interface TaskData {
     description: string;
     status: 'todo' | 'in-progress' | 'review' | 'done';
     priority: 'high' | 'medium' | 'low';
+    context: string | null;
+    paused: number; // 0 = proceed, 1 = paused
     created_at: string; // ISO8601
     updated_at: string; // ISO8601
 }
@@ -36,10 +38,10 @@ export class TaskRepository {
             this.insertTaskStmt = this.db.prepare(`
                 INSERT INTO tasks (
                     task_id, project_id, parent_task_id, description,
-                    status, priority, created_at, updated_at
+                    status, priority, context, paused, created_at, updated_at
                 ) VALUES (
                     @task_id, @project_id, @parent_task_id, @description,
-                    @status, @priority, @created_at, @updated_at
+                    @status, @priority, @context, @paused, @created_at, @updated_at
                 )
             `);
 
@@ -106,7 +108,7 @@ export class TaskRepository {
      */
     public findByProjectId(projectId: string, statusFilter?: TaskData['status']): TaskData[] {
         let sql = `
-            SELECT task_id, project_id, parent_task_id, description, status, priority, created_at, updated_at
+            SELECT task_id, project_id, parent_task_id, description, status, priority, context, paused, created_at, updated_at
             FROM tasks
             WHERE project_id = ?
         `;
@@ -142,7 +144,7 @@ export class TaskRepository {
      */
     public findById(projectId: string, taskId: string): TaskData | undefined {
         const sql = `
-            SELECT task_id, project_id, parent_task_id, description, status, priority, created_at, updated_at
+            SELECT task_id, project_id, parent_task_id, description, status, priority, context, paused, created_at, updated_at
             FROM tasks
             WHERE project_id = ? AND task_id = ?
         `;
@@ -164,7 +166,7 @@ export class TaskRepository {
      */
     public findSubtasks(parentTaskId: string): TaskData[] {
         const sql = `
-            SELECT task_id, project_id, parent_task_id, description, status, priority, created_at, updated_at
+            SELECT task_id, project_id, parent_task_id, description, status, priority, context, paused, created_at, updated_at
             FROM tasks
             WHERE parent_task_id = ?
             ORDER BY created_at ASC
@@ -303,7 +305,7 @@ export class TaskRepository {
         // This query finds tasks in the project with status 'todo'
         // AND for which no dependency exists OR all existing dependencies have status 'done'.
         const sql = `
-            SELECT t.task_id, t.project_id, t.parent_task_id, t.description, t.status, t.priority, t.created_at, t.updated_at
+            SELECT t.task_id, t.project_id, t.parent_task_id, t.description, t.status, t.priority, t.context, t.paused, t.created_at, t.updated_at
             FROM tasks t
             WHERE t.project_id = ? AND t.status = 'todo'
             AND NOT EXISTS (
@@ -312,6 +314,7 @@ export class TaskRepository {
                 JOIN tasks dep_task ON td.depends_on_task_id = dep_task.task_id
                 WHERE td.task_id = t.task_id AND dep_task.status != 'done'
             )
+            AND t.paused = 0
             ORDER BY
                 CASE t.priority
                     WHEN 'high' THEN 1
@@ -339,7 +342,7 @@ export class TaskRepository {
      */
     public findAllTasksForProject(projectId: string): TaskData[] {
         const sql = `
-            SELECT task_id, project_id, parent_task_id, description, status, priority, created_at, updated_at
+            SELECT task_id, project_id, parent_task_id, description, status, priority, context, paused, created_at, updated_at
             FROM tasks
             WHERE project_id = ?
             ORDER BY created_at ASC
@@ -394,13 +397,13 @@ export class TaskRepository {
     public updateTask(
         projectId: string,
         taskId: string,
-        updatePayload: { description?: string; priority?: TaskData['priority']; dependencies?: string[] },
+        updatePayload: { description?: string; priority?: TaskData['priority']; dependencies?: string[]; context?: string | null; paused?: number },
         timestamp: string
     ): TaskData {
 
         const transaction = this.db.transaction(() => {
             const setClauses: string[] = [];
-            const params: (string | null)[] = [];
+            const params: (string | number | null)[] = [];
 
             if (updatePayload.description !== undefined) {
                 setClauses.push('description = ?');
@@ -409,6 +412,14 @@ export class TaskRepository {
             if (updatePayload.priority !== undefined) {
                 setClauses.push('priority = ?');
                 params.push(updatePayload.priority);
+            }
+            if (updatePayload.context !== undefined) {
+                setClauses.push('context = ?');
+                params.push(updatePayload.context);
+            }
+            if (updatePayload.paused !== undefined) {
+                setClauses.push('paused = ?');
+                params.push(updatePayload.paused);
             }
 
             // Always update the timestamp

--- a/src/services/ProjectService.ts
+++ b/src/services/ProjectService.ts
@@ -181,6 +181,8 @@ export class ProjectService {
                     description: task.description,
                     status: task.status,
                     priority: task.priority,
+                    context: task.context ?? null,
+                    paused: task.paused ?? 0,
                     created_at: task.created_at,
                     updated_at: task.updated_at,
                 };

--- a/src/services/TaskService.ts
+++ b/src/services/TaskService.ts
@@ -11,6 +11,8 @@ export interface AddTaskInput {
     dependencies?: string[];
     priority?: 'high' | 'medium' | 'low';
     status?: 'todo' | 'in-progress' | 'review' | 'done';
+    context?: string;
+    paused?: boolean;
 }
 
 // Options for listing tasks
@@ -78,6 +80,8 @@ export class TaskService {
             description: input.description,
             status: input.status ?? 'todo',
             priority: input.priority ?? 'medium',
+            context: input.context ?? null,
+            paused: input.paused ? 1 : 0,
             created_at: now,
             updated_at: now,
         };
@@ -244,6 +248,8 @@ export class TaskService {
                     description: description, // Assuming length validation done by Zod
                     status: 'todo', // Default status
                     priority: 'medium', // Default priority
+                    context: null,
+                    paused: 0,
                     created_at: now,
                     updated_at: now,
                 };
@@ -340,13 +346,21 @@ export class TaskService {
         description?: string;
         priority?: TaskData['priority'];
         dependencies?: string[];
+        context?: string;
+        paused?: boolean;
     }): Promise<FullTaskData> {
         const { project_id, task_id } = input;
         logger.info(`[TaskService] Attempting to update task ${task_id} in project ${project_id}`);
 
         // 1. Validate that at least one field is being updated
-        if (input.description === undefined && input.priority === undefined && input.dependencies === undefined) {
-            throw new ValidationError("At least one field (description, priority, or dependencies) must be provided for update.");
+        if (
+            input.description === undefined &&
+            input.priority === undefined &&
+            input.dependencies === undefined &&
+            input.context === undefined &&
+            input.paused === undefined
+        ) {
+            throw new ValidationError("At least one field (description, priority, dependencies, context, or paused) must be provided for update.");
         }
 
         // 2. Validate Project Existence (using repo method)
@@ -381,10 +395,12 @@ export class TaskService {
         }
 
         // 5. Prepare payload for repository
-        const updatePayload: { description?: string; priority?: TaskData['priority']; dependencies?: string[] } = {};
+        const updatePayload: { description?: string; priority?: TaskData['priority']; dependencies?: string[]; context?: string | null; paused?: number } = {};
         if (input.description !== undefined) updatePayload.description = input.description;
         if (input.priority !== undefined) updatePayload.priority = input.priority;
         if (input.dependencies !== undefined) updatePayload.dependencies = input.dependencies;
+        if (input.context !== undefined) updatePayload.context = input.context;
+        if (input.paused !== undefined) updatePayload.paused = input.paused ? 1 : 0;
 
         // 6. Call Repository update method
         try {

--- a/src/tools/addTaskParams.ts
+++ b/src/tools/addTaskParams.ts
@@ -38,6 +38,16 @@ export const TOOL_PARAMS = z.object({
         .optional()
         .default('todo') // Default value
         .describe("Optional initial status of the task. Defaults to 'todo' if not specified."), // Optional, enum, default
+
+    context: z.string()
+        .max(1000000, "Context cannot exceed 1000000 characters.")
+        .optional()
+        .describe("Optional large context or analysis information for this task."),
+
+    paused: z.boolean()
+        .optional()
+        .default(false)
+        .describe("Optional flag indicating if the task is paused. Defaults to false."),
 });
 
 // Define the expected type for arguments based on the Zod schema

--- a/src/tools/addTaskTool.ts
+++ b/src/tools/addTaskTool.ts
@@ -25,6 +25,8 @@ export const addTaskTool = (server: McpServer, taskService: TaskService): void =
                 dependencies: args.dependencies, // Pass optional fields
                 priority: args.priority,
                 status: args.status,
+                context: args.context,
+                paused: args.paused,
             });
 
             // Format the successful response according to MCP standards

--- a/src/tools/updateTaskParams.ts
+++ b/src/tools/updateTaskParams.ts
@@ -41,12 +41,27 @@ export const UPDATE_TASK_BASE_SCHEMA = z.object({
         .max(50, "A task cannot have more than 50 dependencies.")
         .optional()
         .describe("Optional. The complete list of task IDs (UUIDs) that this task depends on. Replaces the existing list entirely. Max 50 dependencies."), // Optional, array of UUID strings, limit
+
+    context: z.string()
+        .max(1000000, "Context cannot exceed 1000000 characters.")
+        .optional()
+        .describe("Optional. The large context or analysis information for the task."),
+
+    paused: z.boolean()
+        .optional()
+        .describe("Optional. Flag indicating if the task is paused."),
 });
 
 // Refined schema for validation and type inference
 export const TOOL_PARAMS = UPDATE_TASK_BASE_SCHEMA.refine(
-    data => data.description !== undefined || data.priority !== undefined || data.dependencies !== undefined, {
-        message: "At least one field to update (description, priority, or dependencies) must be provided.",
+    data =>
+        data.description !== undefined ||
+        data.priority !== undefined ||
+        data.dependencies !== undefined ||
+        data.context !== undefined ||
+        data.paused !== undefined,
+    {
+        message: "At least one field to update (description, priority, dependencies, context, or paused) must be provided.",
         // path: [], // No specific path, applies to the object
     }
 );

--- a/src/tools/updateTaskTool.ts
+++ b/src/tools/updateTaskTool.ts
@@ -25,6 +25,8 @@ export const updateTaskTool = (server: McpServer, taskService: TaskService): voi
                 description: args.description,
                 priority: args.priority,
                 dependencies: args.dependencies,
+                context: args.context,
+                paused: args.paused,
             });
 
             // Format the successful response

--- a/src/types/taskTypes.ts
+++ b/src/types/taskTypes.ts
@@ -20,6 +20,8 @@ export interface Task {
     description: string;
     status: TaskStatus;
     priority: TaskPriority;
+    context: string | null;
+    paused: boolean;
     created_at: string; // ISO8601 format
     updated_at: string; // ISO8601 format
     dependencies?: string[]; // Array of task_ids this task depends on
@@ -34,6 +36,8 @@ export interface TaskUpdatePayload {
     description?: string;
     priority?: TaskPriority;
     dependencies?: string[]; // Represents the complete new list of dependencies
+    context?: string;
+    paused?: boolean;
 }
 
 /**
@@ -47,6 +51,8 @@ export interface TaskDbObject {
     description: string;
     status: TaskStatus;
     priority: TaskPriority;
+    context: string | null;
+    paused: number;
     created_at: string;
     updated_at: string;
 }


### PR DESCRIPTION
## Summary
- allow tasks to store large context text and paused state
- expose new fields through add and update task tools
- skip paused tasks when retrieving the next task to work on

## Testing
- `npm run lint` *(fails: 2059 problems (1 error, 2058 warnings))*
- `npm run build`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68aa1bfcb0e8832b9ae08f8f80edddf2