### PR TITLE
Add simple web UI for project editing

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Project Editor</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 20px; }
+    textarea { width: 100%; height: 4em; }
+    ul { list-style-type: none; padding-left: 1em; }
+    li { margin-bottom: 1em; }
+    .task { border: 1px solid #ccc; padding: 10px; border-radius: 4px; }
+  </style>
+</head>
+<body>
+  <h1>Project Viewer</h1>
+  <div>
+    <input id="projectId" placeholder="Project ID" />
+    <button id="loadBtn">Load Project</button>
+  </div>
+  <div id="projectArea" style="display:none;">
+    <h2 id="projectName"></h2>
+    <ul id="taskList"></ul>
+  </div>
+  <script>
+    async function loadProject() {
+      const projectId = document.getElementById('projectId').value.trim();
+      if (!projectId) return;
+      const res = await fetch('/api/projects/' + encodeURIComponent(projectId));
+      if (!res.ok) { alert('Project not found'); return; }
+      const data = await res.json();
+      document.getElementById('projectArea').style.display = 'block';
+      document.getElementById('projectName').textContent = data.project.name;
+      const container = document.getElementById('taskList');
+      container.innerHTML = '';
+      function renderTasks(tasks, parent) {
+        tasks.forEach(task => {
+          const li = document.createElement('li');
+          li.className = 'task';
+          li.innerHTML = `
+            <div><strong>${task.description}</strong></div>
+            <div><label>Description<br><textarea class="desc">${task.description}</textarea></label></div>
+            <div><label>Context<br><textarea class="ctx">${task.context || ''}</textarea></label></div>
+            <div><label>Paused <input type="checkbox" class="paused" ${task.paused ? 'checked' : ''}></label></div>
+            <button class="save">Save</button>
+          `;
+          li.querySelector('.save').addEventListener('click', async () => {
+            const desc = li.querySelector('.desc').value;
+            const ctx = li.querySelector('.ctx').value;
+            const paused = li.querySelector('.paused').checked;
+            const resp = await fetch('/api/tasks/' + task.task_id, {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ project_id: projectId, description: desc, context: ctx, paused })
+            });
+            alert(resp.ok ? 'Saved' : 'Error');
+          });
+          parent.appendChild(li);
+          if (task.subtasks && task.subtasks.length > 0) {
+            const subUl = document.createElement('ul');
+            parent.appendChild(subUl);
+            renderTasks(task.subtasks, subUl);
+          }
+        });
+      }
+      renderTasks(data.tasks, container);
+    }
+    document.getElementById('loadBtn').addEventListener('click', loadProject);
+  </script>
+</body>
+</html>

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,7 +1,15 @@
-﻿import { createServer } from "./createServer.js";
+import { createServer } from "./createServer.js";
 import { logger } from "./utils/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 // import { WebSocketServerTransport } from "@modelcontextprotocol/sdk/server/ws.js"; // Example for WebSocket
+import http from "node:http";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { DatabaseManager } from "./db/DatabaseManager.js";
+import { ProjectRepository } from "./repositories/ProjectRepository.js";
+import { TaskRepository } from "./repositories/TaskRepository.js";
+import { ProjectService, TaskService } from "./services/index.js";
 
 const main = async () => {
     try {
@@ -17,6 +25,106 @@ const main = async () => {
 
         logger.info("MCP Server connected and listening");
 
+        // --- UI Server Setup ---
+        const __filename = fileURLToPath(import.meta.url);
+        const __dirname = path.dirname(__filename);
+
+        // Instantiate services for API endpoints
+        const dbManager = DatabaseManager.getInstance();
+        const db = dbManager.getDb();
+        const projectRepository = new ProjectRepository(db);
+        const taskRepository = new TaskRepository(db);
+        const projectService = new ProjectService(db, projectRepository, taskRepository);
+        const taskService = new TaskService(db, taskRepository, projectRepository);
+
+        const httpServer = http.createServer(async (req, res) => {
+            try {
+                if (!req.url) {
+                    res.statusCode = 400;
+                    res.end();
+                    return;
+                }
+
+                // API: Get project with tasks
+                if (req.method === "GET" && req.url.startsWith("/api/projects/")) {
+                    const projectId = decodeURIComponent(req.url.split("/").pop() || "");
+                    const project = await projectService.getProjectById(projectId);
+                    if (!project) {
+                        res.statusCode = 404;
+                        res.setHeader("Content-Type", "application/json");
+                        res.end(JSON.stringify({ error: "Project not found" }));
+                        return;
+                    }
+                    const tasks = await taskService.listTasks({ project_id: projectId, include_subtasks: true });
+                    res.setHeader("Content-Type", "application/json");
+                    res.end(JSON.stringify({ project, tasks }));
+                    return;
+                }
+
+                // API: Update task details
+                if (req.method === "POST" && req.url.startsWith("/api/tasks/")) {
+                    const taskId = decodeURIComponent(req.url.split("/").pop() || "");
+                    let body = "";
+                    req.on("data", chunk => {
+                        body += chunk;
+                    });
+                    req.on("end", async () => {
+                        try {
+                            const data = JSON.parse(body || "{}");
+                            const { project_id, description, context, paused } = data;
+                            const updated = await taskService.updateTask({
+                                project_id,
+                                task_id: taskId,
+                                description,
+                                context,
+                                paused,
+                            });
+                            res.setHeader("Content-Type", "application/json");
+                            res.end(JSON.stringify(updated));
+                        } catch (err) {
+                            res.statusCode = 400;
+                            res.setHeader("Content-Type", "application/json");
+                            res.end(JSON.stringify({ error: (err as Error).message }));
+                        }
+                    });
+                    return;
+                }
+
+                // Static file serving
+                const filePath = path.join(
+                    __dirname,
+                    "../public",
+                    req.url === "/" ? "index.html" : req.url
+                );
+                fs.readFile(filePath, (err, content) => {
+                    if (err) {
+                        res.statusCode = 404;
+                        res.end("Not Found");
+                        return;
+                    }
+                    const ext = path.extname(filePath);
+                    const contentType =
+                        ext === ".html"
+                            ? "text/html"
+                            : ext === ".js"
+                                ? "text/javascript"
+                                : ext === ".css"
+                                    ? "text/css"
+                                    : "text/plain";
+                    res.setHeader("Content-Type", contentType);
+                    res.end(content);
+                });
+            } catch (err) {
+                res.statusCode = 500;
+                res.setHeader("Content-Type", "application/json");
+                res.end(JSON.stringify({ error: "Internal Server Error" }));
+            }
+        });
+
+        const port = Number(process.env.UI_PORT) || 3000;
+        httpServer.listen(port, () => {
+            logger.info(`UI available at http://localhost:${port}`);
+        });
     } catch (error) {
         logger.error("Failed to start server", error);
         process.exit(1); // Exit if server fails to start
@@ -24,3 +132,4 @@ const main = async () => {
 };
 
 main();
+


### PR DESCRIPTION
## Summary
- Serve a basic HTTP UI alongside the MCP server for viewing and editing project tasks
- Provide REST-style endpoints to fetch project data and update task descriptions, context, and pause flag
- Add static HTML interface for entering a project ID, editing tasks, and toggling pause state

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aa4bcf7f48832b86d1220015be5528