### PR TITLE
Add work queue tools for dynamic project requests

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -17,6 +17,13 @@
     <input id="projectId" placeholder="Project ID" />
     <button id="loadBtn">Load Project</button>
   </div>
+  <h2>Available Projects</h2>
+  <table border="1" cellpadding="5" cellspacing="0">
+    <thead>
+      <tr><th>Project ID</th><th>Description</th></tr>
+    </thead>
+    <tbody id="projectsTableBody"></tbody>
+  </table>
     <div id="projectArea" style="display:none;">
       <h2 id="projectName"></h2>
       <ul id="taskList"></ul>
@@ -27,9 +34,32 @@
       </div>
     </div>
     <script>
-    async function loadProject() {
-      const projectId = document.getElementById('projectId').value.trim();
+    async function loadProjects() {
+      const res = await fetch('/api/projects');
+      if (!res.ok) return;
+      const data = await res.json();
+      const tbody = document.getElementById('projectsTableBody');
+      tbody.innerHTML = '';
+      data.projects.forEach(p => {
+        const tr = document.createElement('tr');
+        const idTd = document.createElement('td');
+        const link = document.createElement('a');
+        link.href = '#';
+        link.textContent = p.project_id;
+        link.addEventListener('click', e => { e.preventDefault(); loadProject(p.project_id); });
+        idTd.appendChild(link);
+        const descTd = document.createElement('td');
+        descTd.textContent = p.name;
+        tr.appendChild(idTd);
+        tr.appendChild(descTd);
+        tbody.appendChild(tr);
+      });
+    }
+
+    async function loadProject(projectId) {
+      projectId = projectId || document.getElementById('projectId').value.trim();
       if (!projectId) return;
+      document.getElementById('projectId').value = projectId;
       const res = await fetch('/api/projects/' + encodeURIComponent(projectId));
       if (!res.ok) { alert('Project not found'); return; }
       const data = await res.json();
@@ -88,10 +118,10 @@
             li.dataset.queueId = item.queue_id;
             list.appendChild(li);
           });
-        }
-        area.style.display = 'block';
       }
-      document.getElementById('loadBtn').addEventListener('click', loadProject);
+      area.style.display = 'block';
+    }
+      document.getElementById('loadBtn').addEventListener('click', () => loadProject());
       document.getElementById('clearQueueBtn').addEventListener('click', async () => {
         const projectId = document.getElementById('projectId').value.trim();
         const ids = Array.from(document.querySelectorAll('#queueList li')).map(li => li.dataset.queueId);
@@ -102,6 +132,7 @@
         });
         await loadQueue(projectId);
       });
+      loadProjects();
     </script>
 </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -17,11 +17,16 @@
     <input id="projectId" placeholder="Project ID" />
     <button id="loadBtn">Load Project</button>
   </div>
-  <div id="projectArea" style="display:none;">
-    <h2 id="projectName"></h2>
-    <ul id="taskList"></ul>
-  </div>
-  <script>
+    <div id="projectArea" style="display:none;">
+      <h2 id="projectName"></h2>
+      <ul id="taskList"></ul>
+      <div id="queueArea" style="display:none;">
+        <h2>Work Queue</h2>
+        <ul id="queueList"></ul>
+        <button id="clearQueueBtn">Clear Queue</button>
+      </div>
+    </div>
+    <script>
     async function loadProject() {
       const projectId = document.getElementById('projectId').value.trim();
       if (!projectId) return;
@@ -62,9 +67,35 @@
           }
         });
       }
-      renderTasks(data.tasks, container);
-    }
-    document.getElementById('loadBtn').addEventListener('click', loadProject);
-  </script>
+        renderTasks(data.tasks, container);
+        await loadQueue(projectId);
+      }
+      async function loadQueue(projectId) {
+        const res = await fetch('/api/work-queue/' + encodeURIComponent(projectId));
+        if (!res.ok) return;
+        const data = await res.json();
+        const area = document.getElementById('queueArea');
+        const list = document.getElementById('queueList');
+        list.innerHTML = '';
+        data.queue.forEach(item => {
+          const li = document.createElement('li');
+          li.textContent = item.request;
+          li.dataset.queueId = item.queue_id;
+          list.appendChild(li);
+        });
+        area.style.display = data.queue.length ? 'block' : 'none';
+      }
+      document.getElementById('loadBtn').addEventListener('click', loadProject);
+      document.getElementById('clearQueueBtn').addEventListener('click', async () => {
+        const projectId = document.getElementById('projectId').value.trim();
+        const ids = Array.from(document.querySelectorAll('#queueList li')).map(li => li.dataset.queueId);
+        await fetch('/api/work-queue/' + encodeURIComponent(projectId), {
+          method: 'DELETE',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ queue_ids: ids })
+        });
+        await loadQueue(projectId);
+      });
+    </script>
 </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -77,13 +77,19 @@
         const area = document.getElementById('queueArea');
         const list = document.getElementById('queueList');
         list.innerHTML = '';
-        data.queue.forEach(item => {
+        if (data.queue.length === 0) {
           const li = document.createElement('li');
-          li.textContent = item.request;
-          li.dataset.queueId = item.queue_id;
+          li.textContent = 'No queued requests';
           list.appendChild(li);
-        });
-        area.style.display = data.queue.length ? 'block' : 'none';
+        } else {
+          data.queue.forEach(item => {
+            const li = document.createElement('li');
+            li.textContent = item.request;
+            li.dataset.queueId = item.queue_id;
+            list.appendChild(li);
+          });
+        }
+        area.style.display = 'block';
       }
       document.getElementById('loadBtn').addEventListener('click', loadProject);
       document.getElementById('clearQueueBtn').addEventListener('click', async () => {

--- a/src/config/ConfigurationManager.ts
+++ b/src/config/ConfigurationManager.ts
@@ -55,6 +55,7 @@ export class ConfigurationManager {
                 }
             } else {
                 // Basic busy wait if locked (consider a more robust async lock if high contention is expected)
+                // eslint-disable-next-line no-empty
                 while (ConfigurationManager.instanceLock) { }
                 // Re-check instance after wait
                 if (!ConfigurationManager.instance) {

--- a/src/db/schema.sql
+++ b/src/db/schema.sql
@@ -54,3 +54,17 @@ CREATE INDEX IF NOT EXISTS idx_tasks_created_at ON tasks(created_at);
 -- Indexes on task_dependencies table
 CREATE INDEX IF NOT EXISTS idx_task_dependencies_task_id ON task_dependencies(task_id);
 CREATE INDEX IF NOT EXISTS idx_task_dependencies_depends_on_task_id ON task_dependencies(depends_on_task_id);
+
+-- Table: work_queue
+-- Stores pending work requests for projects
+CREATE TABLE IF NOT EXISTS work_queue (
+    queue_id TEXT PRIMARY KEY NOT NULL, -- UUID
+    project_id TEXT NOT NULL,
+    request TEXT NOT NULL,
+    created_at TEXT NOT NULL, -- ISO8601 format
+    FOREIGN KEY (project_id) REFERENCES projects(project_id) ON DELETE CASCADE
+);
+
+-- Indexes on work_queue table
+CREATE INDEX IF NOT EXISTS idx_work_queue_project_id ON work_queue(project_id);
+CREATE INDEX IF NOT EXISTS idx_work_queue_created_at ON work_queue(created_at);

--- a/src/repositories/ProjectRepository.ts
+++ b/src/repositories/ProjectRepository.ts
@@ -74,5 +74,18 @@ export class ProjectRepository {
         }
     }
 
-    // Add other methods as needed (e.g., update, list)
+    /**
+     * Lists all projects.
+     * @returns Array of project records.
+     */
+    public findAll(): ProjectData[] {
+        const sql = `SELECT project_id, name, created_at FROM projects ORDER BY created_at DESC`;
+        try {
+            const stmt = this.db.prepare(sql);
+            return stmt.all() as ProjectData[];
+        } catch (error) {
+            logger.error(`[ProjectRepository] Failed to list projects:`, error);
+            throw error; // Re-throw
+        }
+    }
 }

--- a/src/repositories/WorkQueueRepository.ts
+++ b/src/repositories/WorkQueueRepository.ts
@@ -1,0 +1,69 @@
+import { Database as Db } from 'better-sqlite3';
+import { logger } from '../utils/logger.js';
+
+export interface QueueItemData {
+    queue_id: string;
+    project_id: string;
+    request: string;
+    created_at: string;
+}
+
+export class WorkQueueRepository {
+    private db: Db;
+
+    constructor(db: Db) {
+        this.db = db;
+    }
+
+    public enqueue(item: QueueItemData): void {
+        const sql = `
+            INSERT INTO work_queue (queue_id, project_id, request, created_at)
+            VALUES (@queue_id, @project_id, @request, @created_at)
+        `;
+        try {
+            const stmt = this.db.prepare(sql);
+            const info = stmt.run(item);
+            logger.info(`[WorkQueueRepository] Enqueued request ${item.queue_id} for project ${item.project_id}, changes: ${info.changes}`);
+        } catch (error) {
+            logger.error(`[WorkQueueRepository] Failed to enqueue request ${item.queue_id}:`, error);
+            throw error;
+        }
+    }
+
+    public list(projectId: string): QueueItemData[] {
+        const sql = `
+            SELECT queue_id, project_id, request, created_at
+            FROM work_queue
+            WHERE project_id = ?
+            ORDER BY created_at ASC
+        `;
+        try {
+            const stmt = this.db.prepare(sql);
+            return stmt.all(projectId) as QueueItemData[];
+        } catch (error) {
+            logger.error(`[WorkQueueRepository] Failed to fetch queue for project ${projectId}:`, error);
+            throw error;
+        }
+    }
+
+    public delete(projectId: string, queueIds: string[]): number {
+        if (queueIds.length === 0) {
+            return 0;
+        }
+        const placeholders = queueIds.map(() => '?').join(',');
+        const sql = `
+            DELETE FROM work_queue
+            WHERE project_id = ? AND queue_id IN (${placeholders})
+        `;
+        const params = [projectId, ...queueIds];
+        try {
+            const stmt = this.db.prepare(sql);
+            const info = stmt.run(...params);
+            logger.info(`[WorkQueueRepository] Deleted ${info.changes} queue items from project ${projectId}.`);
+            return info.changes;
+        } catch (error) {
+            logger.error(`[WorkQueueRepository] Failed to delete queue items from project ${projectId}:`, error);
+            throw error;
+        }
+    }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,7 +9,8 @@ import { fileURLToPath } from "node:url";
 import { DatabaseManager } from "./db/DatabaseManager.js";
 import { ProjectRepository } from "./repositories/ProjectRepository.js";
 import { TaskRepository } from "./repositories/TaskRepository.js";
-import { ProjectService, TaskService } from "./services/index.js";
+import { WorkQueueRepository } from "./repositories/WorkQueueRepository.js";
+import { ProjectService, TaskService, WorkQueueService } from "./services/index.js";
 
 const main = async () => {
     try {
@@ -36,6 +37,8 @@ const main = async () => {
         const taskRepository = new TaskRepository(db);
         const projectService = new ProjectService(db, projectRepository, taskRepository);
         const taskService = new TaskService(db, taskRepository, projectRepository);
+        const workQueueRepository = new WorkQueueRepository(db);
+        const workQueueService = new WorkQueueService(workQueueRepository, projectRepository);
 
         const httpServer = http.createServer(async (req, res) => {
             try {
@@ -58,6 +61,38 @@ const main = async () => {
                     const tasks = await taskService.listTasks({ project_id: projectId, include_subtasks: true });
                     res.setHeader("Content-Type", "application/json");
                     res.end(JSON.stringify({ project, tasks }));
+                    return;
+                }
+
+                // API: Work queue - list items for a project
+                if (req.method === "GET" && req.url.startsWith("/api/work-queue/")) {
+                    const projectId = decodeURIComponent(req.url.split("/").pop() || "");
+                    const queue = await workQueueService.list(projectId);
+                    res.setHeader("Content-Type", "application/json");
+                    res.end(JSON.stringify({ queue }));
+                    return;
+                }
+
+                // API: Work queue - clear items for a project
+                if (req.method === "DELETE" && req.url.startsWith("/api/work-queue/")) {
+                    const projectId = decodeURIComponent(req.url.split("/").pop() || "");
+                    let body = "";
+                    req.on("data", chunk => {
+                        body += chunk;
+                    });
+                    req.on("end", async () => {
+                        try {
+                            const data = JSON.parse(body || "{}");
+                            const ids: string[] = Array.isArray(data.queue_ids) ? data.queue_ids : [];
+                            await workQueueService.clear(projectId, ids);
+                            res.statusCode = 204;
+                            res.end();
+                        } catch (err) {
+                            res.statusCode = 400;
+                            res.setHeader("Content-Type", "application/json");
+                            res.end(JSON.stringify({ error: (err as Error).message }));
+                        }
+                    });
                     return;
                 }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -49,6 +49,13 @@ const main = async () => {
                 }
 
                 // API: Get project with tasks
+                if (req.method === "GET" && req.url === "/api/projects") {
+                    const projects = await projectService.listProjects();
+                    res.setHeader("Content-Type", "application/json");
+                    res.end(JSON.stringify({ projects }));
+                    return;
+                }
+
                 if (req.method === "GET" && req.url.startsWith("/api/projects/")) {
                     const projectId = decodeURIComponent(req.url.split("/").pop() || "");
                     const project = await projectService.getProjectById(projectId);

--- a/src/services/ProjectService.ts
+++ b/src/services/ProjectService.ts
@@ -75,6 +75,19 @@ export class ProjectService {
     }
 
     /**
+     * Lists all projects.
+     */
+    public async listProjects(): Promise<ProjectData[]> {
+        logger.info(`[ProjectService] Listing all projects`);
+        try {
+            return this.projectRepository.findAll();
+        } catch (error) {
+            logger.error(`[ProjectService] Error listing projects:`, error);
+            throw error;
+        }
+    }
+
+    /**
      * Exports all data for a given project as a JSON string.
      */
     public async exportProject(projectId: string): Promise<string> {

--- a/src/services/WorkQueueService.ts
+++ b/src/services/WorkQueueService.ts
@@ -1,0 +1,71 @@
+import { v4 as uuidv4 } from 'uuid';
+import { WorkQueueRepository, QueueItemData } from '../repositories/WorkQueueRepository.js';
+import { ProjectRepository } from '../repositories/ProjectRepository.js';
+import { logger } from '../utils/logger.js';
+import { NotFoundError } from '../utils/errors.js';
+
+export class WorkQueueService {
+    private workQueueRepository: WorkQueueRepository;
+    private projectRepository: ProjectRepository;
+
+    constructor(workQueueRepository: WorkQueueRepository, projectRepository: ProjectRepository) {
+        this.workQueueRepository = workQueueRepository;
+        this.projectRepository = projectRepository;
+    }
+
+    public async enqueue(projectId: string, request: string): Promise<QueueItemData> {
+        logger.info(`[WorkQueueService] Enqueue request for project ${projectId}`);
+        const projectExists = this.projectRepository.findById(projectId);
+        if (!projectExists) {
+            logger.warn(`[WorkQueueService] Project not found: ${projectId}`);
+            throw new NotFoundError(`Project with ID ${projectId} not found.`);
+        }
+
+        const item: QueueItemData = {
+            queue_id: uuidv4(),
+            project_id: projectId,
+            request,
+            created_at: new Date().toISOString(),
+        };
+
+        try {
+            this.workQueueRepository.enqueue(item);
+            return item;
+        } catch (error) {
+            logger.error(`[WorkQueueService] Failed to enqueue request for project ${projectId}:`, error);
+            throw error;
+        }
+    }
+
+    public async list(projectId: string): Promise<QueueItemData[]> {
+        logger.info(`[WorkQueueService] Listing queue for project ${projectId}`);
+        const projectExists = this.projectRepository.findById(projectId);
+        if (!projectExists) {
+            logger.warn(`[WorkQueueService] Project not found: ${projectId}`);
+            throw new NotFoundError(`Project with ID ${projectId} not found.`);
+        }
+
+        try {
+            return this.workQueueRepository.list(projectId);
+        } catch (error) {
+            logger.error(`[WorkQueueService] Failed to list queue for project ${projectId}:`, error);
+            throw error;
+        }
+    }
+
+    public async clear(projectId: string, queueIds: string[]): Promise<number> {
+        logger.info(`[WorkQueueService] Clearing ${queueIds.length} queue items from project ${projectId}`);
+        const projectExists = this.projectRepository.findById(projectId);
+        if (!projectExists) {
+            logger.warn(`[WorkQueueService] Project not found: ${projectId}`);
+            throw new NotFoundError(`Project with ID ${projectId} not found.`);
+        }
+
+        try {
+            return this.workQueueRepository.delete(projectId, queueIds);
+        } catch (error) {
+            logger.error(`[WorkQueueService] Failed to clear queue items for project ${projectId}:`, error);
+            throw error;
+        }
+    }
+}

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,5 +1,6 @@
-﻿export * from './ProjectService.js';
+export * from './ProjectService.js';
 export * from './TaskService.js'; // Added TaskService export
+export * from './WorkQueueService.js';
 // Remove or comment out ExampleService if it's not being used
 // export * from './ExampleService.js';
 // Add other service exports here

--- a/src/tools/clearWorkQueueParams.ts
+++ b/src/tools/clearWorkQueueParams.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod';
+
+export const TOOL_NAME = 'clear_work_queue';
+
+export const TOOL_DESCRIPTION = `
+Remove processed requests from a project's work queue.
+Call this after handling items returned by get_work_queue.
+`;
+
+export const TOOL_PARAMS = z.object({
+    project_id: z.string().uuid().describe('ID of the project whose queue items should be cleared.'),
+    queue_ids: z.array(z.string().uuid()).nonempty().describe('IDs of queue items to remove.'),
+});
+
+export type ClearWorkQueueArgs = z.infer<typeof TOOL_PARAMS>;

--- a/src/tools/clearWorkQueueTool.ts
+++ b/src/tools/clearWorkQueueTool.ts
@@ -1,0 +1,28 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
+import { TOOL_NAME, TOOL_DESCRIPTION, TOOL_PARAMS, ClearWorkQueueArgs } from './clearWorkQueueParams.js';
+import { WorkQueueService } from '../services/WorkQueueService.js';
+import { logger } from '../utils/logger.js';
+import { NotFoundError } from '../utils/errors.js';
+
+export const clearWorkQueueTool = (server: McpServer, workQueueService: WorkQueueService): void => {
+    const processRequest = async (args: ClearWorkQueueArgs) => {
+        logger.info(`[${TOOL_NAME}] Received request`, args);
+        try {
+            const deleted = await workQueueService.clear(args.project_id, args.queue_ids);
+            return {
+                content: [{ type: 'text' as const, text: JSON.stringify({ deleted }) }],
+            };
+        } catch (error) {
+            logger.error(`[${TOOL_NAME}] Error processing request:`, error);
+            if (error instanceof NotFoundError) {
+                throw new McpError(ErrorCode.InvalidParams, error.message);
+            }
+            const message = error instanceof Error ? error.message : 'Failed to clear work queue.';
+            throw new McpError(ErrorCode.InternalError, message);
+        }
+    };
+
+    server.tool(TOOL_NAME, TOOL_DESCRIPTION, TOOL_PARAMS.shape, processRequest);
+    logger.info(`[${TOOL_NAME}] Tool registered successfully.`);
+};

--- a/src/tools/enqueueRequestParams.ts
+++ b/src/tools/enqueueRequestParams.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod';
+
+export const TOOL_NAME = 'enqueue_request';
+
+export const TOOL_DESCRIPTION = `
+Add a new request to a project's work queue.
+Use this to queue additional instructions so the AI can revisit its plans.
+`;
+
+export const TOOL_PARAMS = z.object({
+    project_id: z.string().uuid().describe('ID of the project receiving the request.'),
+    request: z.string().min(1, 'Request is required.').describe('Description of the request to enqueue.'),
+});
+
+export type EnqueueRequestArgs = z.infer<typeof TOOL_PARAMS>;

--- a/src/tools/enqueueRequestTool.ts
+++ b/src/tools/enqueueRequestTool.ts
@@ -1,0 +1,28 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
+import { TOOL_NAME, TOOL_DESCRIPTION, TOOL_PARAMS, EnqueueRequestArgs } from './enqueueRequestParams.js';
+import { WorkQueueService } from '../services/WorkQueueService.js';
+import { logger } from '../utils/logger.js';
+import { NotFoundError } from '../utils/errors.js';
+
+export const enqueueRequestTool = (server: McpServer, workQueueService: WorkQueueService): void => {
+    const processRequest = async (args: EnqueueRequestArgs) => {
+        logger.info(`[${TOOL_NAME}] Received request`, args);
+        try {
+            const item = await workQueueService.enqueue(args.project_id, args.request);
+            return {
+                content: [{ type: 'text' as const, text: JSON.stringify(item) }],
+            };
+        } catch (error) {
+            logger.error(`[${TOOL_NAME}] Error processing request:`, error);
+            if (error instanceof NotFoundError) {
+                throw new McpError(ErrorCode.InvalidParams, error.message);
+            }
+            const message = error instanceof Error ? error.message : 'Failed to enqueue request.';
+            throw new McpError(ErrorCode.InternalError, message);
+        }
+    };
+
+    server.tool(TOOL_NAME, TOOL_DESCRIPTION, TOOL_PARAMS.shape, processRequest);
+    logger.info(`[${TOOL_NAME}] Tool registered successfully.`);
+};

--- a/src/tools/getWorkQueueParams.ts
+++ b/src/tools/getWorkQueueParams.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+
+export const TOOL_NAME = 'get_work_queue';
+
+export const TOOL_DESCRIPTION = `
+Retrieve pending requests from a project's work queue.
+After processing these requests, call clear_work_queue to remove them.
+`;
+
+export const TOOL_PARAMS = z.object({
+    project_id: z.string().uuid().describe('ID of the project whose queue should be read.'),
+});
+
+export type GetWorkQueueArgs = z.infer<typeof TOOL_PARAMS>;

--- a/src/tools/getWorkQueueTool.ts
+++ b/src/tools/getWorkQueueTool.ts
@@ -1,0 +1,28 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
+import { TOOL_NAME, TOOL_DESCRIPTION, TOOL_PARAMS, GetWorkQueueArgs } from './getWorkQueueParams.js';
+import { WorkQueueService } from '../services/WorkQueueService.js';
+import { logger } from '../utils/logger.js';
+import { NotFoundError } from '../utils/errors.js';
+
+export const getWorkQueueTool = (server: McpServer, workQueueService: WorkQueueService): void => {
+    const processRequest = async (args: GetWorkQueueArgs) => {
+        logger.info(`[${TOOL_NAME}] Received request`, args);
+        try {
+            const items = await workQueueService.list(args.project_id);
+            return {
+                content: [{ type: 'text' as const, text: JSON.stringify(items) }],
+            };
+        } catch (error) {
+            logger.error(`[${TOOL_NAME}] Error processing request:`, error);
+            if (error instanceof NotFoundError) {
+                throw new McpError(ErrorCode.InvalidParams, error.message);
+            }
+            const message = error instanceof Error ? error.message : 'Failed to retrieve work queue.';
+            throw new McpError(ErrorCode.InternalError, message);
+        }
+    };
+
+    server.tool(TOOL_NAME, TOOL_DESCRIPTION, TOOL_PARAMS.shape, processRequest);
+    logger.info(`[${TOOL_NAME}] Tool registered successfully.`);
+};

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -4,7 +4,8 @@ import { logger } from "../utils/index.js"; // Now using barrel file
 import { DatabaseManager } from "../db/DatabaseManager.js";
 import { ProjectRepository } from "../repositories/ProjectRepository.js";
 import { TaskRepository } from "../repositories/TaskRepository.js"; // Added TaskRepository import
-import { ProjectService, TaskService } from "../services/index.js"; // Using barrel file, added TaskService
+import { WorkQueueRepository } from "../repositories/WorkQueueRepository.js";
+import { ProjectService, TaskService, WorkQueueService } from "../services/index.js"; // Using barrel file, added TaskService
 
 // Import tool registration functions
 // import { exampleTool } from "./exampleTool.js"; // Commenting out example
@@ -20,6 +21,9 @@ import { importProjectTool } from "./importProjectTool.js";
 import { updateTaskTool } from "./updateTaskTool.js"; // Import the new tool
 import { deleteTaskTool } from "./deleteTaskTool.js"; // Import deleteTask tool
 import { deleteProjectTool } from "./deleteProjectTool.js"; // Import deleteProject tool
+import { enqueueRequestTool } from "./enqueueRequestTool.js";
+import { getWorkQueueTool } from "./getWorkQueueTool.js";
+import { clearWorkQueueTool } from "./clearWorkQueueTool.js";
 // import { yourTool } from "./yourTool.js"; // Add other new tool imports here
 
 /**
@@ -40,10 +44,12 @@ export function registerTools(server: McpServer): void {
         // Instantiate Repositories
         const projectRepository = new ProjectRepository(db);
         const taskRepository = new TaskRepository(db); // Instantiate TaskRepository
+        const workQueueRepository = new WorkQueueRepository(db);
 
         // Instantiate Services
         const projectService = new ProjectService(db, projectRepository, taskRepository); // Pass db and both repos
         const taskService = new TaskService(db, taskRepository, projectRepository); // Instantiate TaskService, passing db and repos
+        const workQueueService = new WorkQueueService(workQueueRepository, projectRepository);
 
         // --- Register Tools ---
         // Register each tool, passing necessary services
@@ -62,6 +68,9 @@ export function registerTools(server: McpServer): void {
         updateTaskTool(server, taskService); // Register the new updateTask tool
         deleteTaskTool(server, taskService); // Register deleteTask tool
         deleteProjectTool(server, projectService); // Register deleteProject tool (uses ProjectService)
+        enqueueRequestTool(server, workQueueService);
+        getWorkQueueTool(server, workQueueService);
+        clearWorkQueueTool(server, workQueueService);
         // ... etc.
 
         logger.info("All tools registered successfully.");


### PR DESCRIPTION
## Summary
- add `work_queue` table and indexes to store pending project requests
- implement repository and service for enqueueing, listing, and clearing queue items
- expose `enqueue_request`, `get_work_queue`, and `clear_work_queue` tools and register them

## Testing
- `npm run lint`
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68aa7d3a4b10832ba94b6bf92dbbb638